### PR TITLE
Make API key optional with DEMO_KEY default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ coverage/
 .vscode/
 .idea/
 *.tsbuildinfo
+
+CLAUDE.md
+.claude/

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ npm install mars-photo-sdk
 ```typescript
 import { MarsPhotosClient } from "mars-photo-sdk";
 
-const client = new MarsPhotosClient({
-  apiKey: "YOUR_NASA_API_KEY",
-});
+// Zero config - uses DEMO_KEY for quick testing
+const client = new MarsPhotosClient();
 
 // Get photos by earth date
 const photos = await client.photos.get({
@@ -37,9 +36,19 @@ const photos = await client.photos.get({
 console.log(`Found ${photos.length} photos`);
 ```
 
-## Getting an API Key
+## API Key
 
-Get your free NASA API key at [https://api.nasa.gov/#signUp](https://api.nasa.gov/#signUp)
+The SDK uses NASA's `DEMO_KEY` by default for testing and development. For production use, get your free API key at [https://api.nasa.gov/#signUp](https://api.nasa.gov/#signUp):
+
+```typescript
+const client = new MarsPhotosClient({
+  apiKey: "YOUR_NASA_API_KEY",
+});
+```
+
+**Rate Limits:**
+- `DEMO_KEY`: 50 requests per hour
+- Personal API key: 1,000 requests per hour
 
 ## API Reference
 
@@ -47,9 +56,19 @@ Get your free NASA API key at [https://api.nasa.gov/#signUp](https://api.nasa.go
 
 ```typescript
 const client = new MarsPhotosClient({
-  apiKey: "YOUR_NASA_API_KEY", // Required
+  apiKey: "YOUR_NASA_API_KEY", // Optional, defaults to DEMO_KEY
   baseUrl: "https://api.nasa.gov/...", // Optional, custom API URL
   fetch: customFetch, // Optional, custom fetch implementation
+});
+```
+
+**For browser/CORS use cases:**
+
+The Heroku community mirror allows cross-origin requests and doesn't require an API key:
+
+```typescript
+const client = new MarsPhotosClient({
+  baseUrl: "https://mars-photos.herokuapp.com/api/v1",
 });
 ```
 

--- a/src/client/config.ts
+++ b/src/client/config.ts
@@ -6,14 +6,21 @@ import { ConfigurationError } from "./errors";
 export const DEFAULT_BASE_URL = "https://api.nasa.gov/mars-photos/api/v1";
 
 /**
+ * Default NASA API key for testing/development
+ * Get your own key at https://api.nasa.gov/#signUp for production use
+ */
+export const DEFAULT_API_KEY = "DEMO_KEY";
+
+/**
  * Client configuration options
  */
 export interface ClientConfig {
   /**
-   * NASA API key - required
-   * Get one at https://api.nasa.gov/#signUp
+   * NASA API key
+   * Defaults to DEMO_KEY if not provided
+   * Get your own at https://api.nasa.gov/#signUp for production use
    */
-  readonly apiKey: string;
+  readonly apiKey?: string;
 
   /**
    * Base URL for NASA API
@@ -47,10 +54,12 @@ export interface NormalizedConfig {
  * @returns Normalized configuration with defaults applied
  * @throws {ConfigurationError} If configuration is invalid
  */
-export function normalizeConfig(config: ClientConfig): NormalizedConfig {
-  if (!config.apiKey || config.apiKey.trim() === "") {
+export function normalizeConfig(config: ClientConfig = {}): NormalizedConfig {
+  const apiKey = config.apiKey?.trim() ?? DEFAULT_API_KEY;
+
+  if (apiKey === "") {
     throw new ConfigurationError(
-      "API key is required. Get one at https://api.nasa.gov/#signUp",
+      "API key cannot be empty. Get one at https://api.nasa.gov/#signUp",
     );
   }
 
@@ -61,7 +70,7 @@ export function normalizeConfig(config: ClientConfig): NormalizedConfig {
   }
 
   return {
-    apiKey: config.apiKey.trim(),
+    apiKey,
     baseUrl: config.baseUrl?.trim() ?? DEFAULT_BASE_URL,
     fetch: fetchImpl,
   };

--- a/src/mars-photos-client.ts
+++ b/src/mars-photos-client.ts
@@ -35,18 +35,21 @@ export class MarsPhotosClient {
   /**
    * Create a new Mars Photos API client
    *
-   * @param config - Client configuration with API key
+   * @param config - Client configuration (optional, defaults to DEMO_KEY)
    * @throws {ConfigurationError} If configuration is invalid
    *
    * @example
    * ```typescript
+   * // Use DEMO_KEY (for testing/development)
+   * const client = new MarsPhotosClient()
+   *
+   * // Use your own API key (recommended for production)
    * const client = new MarsPhotosClient({
-   *   apiKey: 'YOUR_NASA_API_KEY',
-   *   baseUrl: 'https://api.nasa.gov/mars-photos/api/v1' // optional
+   *   apiKey: 'YOUR_NASA_API_KEY'
    * })
    * ```
    */
-  constructor(config: ClientConfig) {
+  constructor(config?: ClientConfig) {
     const normalizedConfig = normalizeConfig(config);
 
     const httpClient = new HttpClient(normalizedConfig);

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,9 +1,28 @@
 import { describe, it, expect } from "vitest";
-import { normalizeConfig, DEFAULT_BASE_URL } from "../../src/client";
+import {
+  normalizeConfig,
+  DEFAULT_BASE_URL,
+  DEFAULT_API_KEY,
+} from "../../src/client";
 import { ConfigurationError } from "../../src";
 
 describe("config normalization", () => {
   describe("normalizeConfig", () => {
+    it("uses DEMO_KEY when no config provided", () => {
+      const config = normalizeConfig();
+
+      expect(config.apiKey).toBe(DEFAULT_API_KEY);
+      expect(config.baseUrl).toBe(DEFAULT_BASE_URL);
+      expect(typeof config.fetch).toBe("function");
+    });
+
+    it("uses DEMO_KEY when no apiKey provided", () => {
+      const config = normalizeConfig({});
+
+      expect(config.apiKey).toBe(DEFAULT_API_KEY);
+      expect(config.baseUrl).toBe(DEFAULT_BASE_URL);
+    });
+
     it("accepts valid configuration", () => {
       const config = normalizeConfig({
         apiKey: "test-key",
@@ -62,7 +81,7 @@ describe("config normalization", () => {
         normalizeConfig({
           apiKey: "",
         });
-      }).toThrow("API key is required");
+      }).toThrow("API key cannot be empty");
     });
 
     it("throws ConfigurationError for whitespace-only apiKey", () => {
@@ -101,6 +120,12 @@ describe("config normalization", () => {
   describe("DEFAULT_BASE_URL", () => {
     it("points to NASA API", () => {
       expect(DEFAULT_BASE_URL).toBe("https://api.nasa.gov/mars-photos/api/v1");
+    });
+  });
+
+  describe("DEFAULT_API_KEY", () => {
+    it("is set to DEMO_KEY", () => {
+      expect(DEFAULT_API_KEY).toBe("DEMO_KEY");
     });
   });
 });


### PR DESCRIPTION
- Add DEFAULT_API_KEY constant set to DEMO_KEY
- Make apiKey optional in ClientConfig interface
- Update normalizeConfig to use DEMO_KEY when no key provided
- Make config parameter optional in MarsPhotosClient constructor
- Add tests for zero-config and empty config scenarios
- Update README with zero-config quick start example
- Document rate limits for DEMO_KEY vs personal keys
- Add Heroku mirror option for CORS use cases

Improves developer experience by allowing instant usage without API key signup, while maintaining clear path to production use with personal API key.